### PR TITLE
crypto: blinding non-const multiplication in Schnorr/ECDSA

### DIFF
--- a/dcrec/secp256k1/common/common.go
+++ b/dcrec/secp256k1/common/common.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"crypto/rand"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+func ScalarBaseMultWithBlinding(k *secp256k1.ModNScalar) (*secp256k1.JacobianPoint, error) {
+	// Generate a random blinding factor r
+	r := new(secp256k1.ModNScalar)
+	var rBytes [32]byte
+	if _, err := rand.Read(rBytes[:]); err != nil {
+		return nil, err
+	}
+	r.SetByteSlice(rBytes[:])
+
+	// Compute (k+r)G
+	kr := new(secp256k1.ModNScalar).Set(k).Add(r)
+	var krG secp256k1.JacobianPoint
+	secp256k1.ScalarBaseMultNonConst(kr, &krG)
+
+	// Compute -rG
+	rNeg := new(secp256k1.ModNScalar).Set(r).Negate()
+	var rNegG secp256k1.JacobianPoint
+	secp256k1.ScalarBaseMultNonConst(rNeg, &rNegG)
+
+	// Convert to affine coordinates so that the addition is constant time
+	krG.ToAffine()
+	rNegG.ToAffine()
+
+	// Add (k+r)G and -rG to get kG
+	var R secp256k1.JacobianPoint
+	secp256k1.AddNonConst(&krG, &rNegG, &R)
+
+	return &R, nil
+}

--- a/dcrec/secp256k1/ecdsa/signature.go
+++ b/dcrec/secp256k1/ecdsa/signature.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4/common"
 )
 
 // References:
@@ -591,12 +592,14 @@ func sign(privKey, nonce *secp256k1.ModNScalar, hash []byte) (*Signature, byte, 
 	//
 	// Step 2.
 	//
-	// Compute kG
+	// Compute kG (with blinding in order to prevent timing side channel attacks)
 	//
 	// Note that the point must be in affine coordinates.
-	k := nonce
-	var kG secp256k1.JacobianPoint
-	secp256k1.ScalarBaseMultNonConst(k, &kG)
+	k := *nonce
+	kG, err := common.ScalarBaseMultWithBlinding(&k)
+	if err != nil {
+		return nil, 0, false
+	}
 	kG.ToAffine()
 
 	// Step 3.
@@ -645,7 +648,7 @@ func sign(privKey, nonce *secp256k1.ModNScalar, hash []byte) (*Signature, byte, 
 	// s = k^-1(e + dr) mod N
 	// Repeat from step 1 if s = 0
 	// s = -s if s > N/2
-	kinv := new(secp256k1.ModNScalar).InverseValNonConst(k)
+	kinv := new(secp256k1.ModNScalar).InverseValNonConst(&k)
 	s := new(secp256k1.ModNScalar).Mul2(privKey, &r).Add(&e).Mul(kinv)
 	if s.IsZero() {
 		return nil, 0, false

--- a/dcrec/secp256k1/schnorr/signature.go
+++ b/dcrec/secp256k1/schnorr/signature.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/decred/dcrd/crypto/blake256"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4/common"
 )
 
 const (
@@ -268,10 +269,12 @@ func schnorrSign(privKey, nonce *secp256k1.ModNScalar, hash []byte) (*Signature,
 	//
 	// Step 4.
 	//
-	// R = kG
-	var R secp256k1.JacobianPoint
+	// R = kG (with blinding in order to prevent timing side channel attacks)
 	k := *nonce
-	secp256k1.ScalarBaseMultNonConst(&k, &R)
+	R, err := common.ScalarBaseMultWithBlinding(&k)
+	if err != nil {
+		return nil, err
+	}
 
 	// Step 5.
 	//


### PR DESCRIPTION
Part of https://github.com/babylonlabs-io/pm/issues/186

This PR introduces blinding for non-const multiplication over nonce in Schnorr and ECDSA.

This repository will be used in covenant emulator